### PR TITLE
Feat/transactions page

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,7 +4,10 @@ class GroupsController < ApplicationController
     @categories = current_user.groups
   end
 
-  def show; end
+  def show
+    @category = Group.find(params[:id])
+    @transactions = @category.entities.order('created_at DESC')
+  end
 
   def new
     @group = Group.new(

--- a/app/views/app/_transaction_card.html.erb
+++ b/app/views/app/_transaction_card.html.erb
@@ -1,0 +1,9 @@
+<script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
+<script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
+
+<div class="container flex flex-col border">
+    <ion-icon name="heart"></ion-icon>
+    <p><%=transaction.name%></p>
+    <p><%=transaction.amount%></p>
+    <p><%=transaction.created_at%></p>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,6 +1,11 @@
 <div class="container flex flex-col">
   <h1>Transactions</h1>
-  <p>Total Amount $ [Pending to Implement]</p>
+  <%# We summ each transaction.amount and get the result in below %>
+  <%total_amount = 0  %>
+    <% @transactions.each do |transaction| %>
+        <%total_amount += transaction.amount%>
+    <%end%>
+  <p>Total Amount $<%=total_amount%></p>
   <% @transactions.each do |transaction| %>
     <%= render 'app/transaction_card', transaction: transaction %>
   <%end%>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,5 +1,9 @@
-This will display Entiteis for each group
-<%# go back button %>
-<%= link_to 'Back', groups_path %>
-<%# Link_to new entity %>
-<%= link_to 'New Transaction', new_entity_path %>
+<div class="container flex flex-col">
+  <h1>Transactions</h1>
+  <p>Total Amount $ [Pending to Implement]</p>
+  <% @transactions.each do |transaction| %>
+    <%= render 'app/transaction_card', transaction: transaction %>
+  <%end%>
+  <%= link_to 'Back', groups_path %>
+  <%= link_to 'New Transaction', new_entity_path %>
+</div>


### PR DESCRIPTION
# Implemented Changes:

- [x] `transactions page`(will display all transactions)
	- [x] For a given category, the list of transactions is presented ordered by the most recent
	- [x] At the top of the page the user could see the total amount for the category (sum of all of the amounts of the transactions in that category).
	- [x] Ther is a button "add a new transaction" at the bottom that brings the user to the page to create a new transaction.
	- [x] When the user clicks on the "back" button (<), the user navigates to the home page.